### PR TITLE
Fix incorrect file reference in lifecycle customization docs

### DIFF
--- a/en/docs/design/lifecycle-management/customize-api-life-cycle.md
+++ b/en/docs/design/lifecycle-management/customize-api-life-cycle.md
@@ -170,7 +170,7 @@ Follow the steps below to add a new state to the default life cycle.
 
         If you want to change the lifecycle image in Publisher, you can follow the steps mentioned below:
 
-        -   Search for **lifeCycleImage** in `defaultTheme.json` file resides in `<APIM-Home>/repository/deployment/server/webapps/publisher/src/main/webapp/site/public/conf` directory and uncomment it.
+        -   Search for **lifeCycleImage** in `userThemes.js` file resides in `<APIM-Home>/repository/deployment/server/webapps/publisher/site/public/conf` directory and uncomment it.
         -   Replace the path with correct path of image. For instance,
 
                 lifeCycleImage: '/publisher/site/public/images/custom-lifecycle.png,


### PR DESCRIPTION
## Summary
- Fixed incorrect file reference from `defaultTheme.json` to `userThemes.js` 
- Corrected file path by removing unnecessary subdirectories
- Addresses issue #9398 where users reported the documented file path does not exist

## Test plan
- [x] Verified the file path correction matches the actual WSO2 API Manager file structure
- [x] Updated documentation to reference the correct `userThemes.js` file

🤖 Generated with [Claude Code](https://claude.ai/code)