### PR TITLE
Fix Note section indentation in Step 4 of distributed deployment guide

### DIFF
--- a/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-simple-scalable-setup.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-simple-scalable-setup.md
@@ -59,7 +59,7 @@ For more information, see [Production Deployment Guidelines](../../../../install
 Create an SSL certificate for each of the WSO2 API-M nodes and import them to the keystore and the truststore. This ensures that hostname mismatch issues in the certificates will not occur.
 
 !!! Note
-The same primary keystore should be used for all API Manager instances to decrypt the registry resources. For more information, see [Configuring the Primary Keystore](../../../../install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager/#configuring-the-primary-keystore).
+    The same primary keystore should be used for all API Manager instances to decrypt the registry resources. For more information, see [Configuring the Primary Keystore](../../../../install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager/#configuring-the-primary-keystore).
 
 For more information, see [Creating SSL Certificates](../../../../install-and-setup/setup/security/configuring-keystores/keystore-basics/creating-new-keystores/).
 


### PR DESCRIPTION
## Summary

This PR fixes a documentation rendering issue where the Note section under Step 4 in the distributed deployment setup guide was not expanding properly.

## Changes Made

- Fixed markdown formatting by adding proper 4-space indentation after the `\!\!\! Note` directive
- The Note section now follows the same formatting pattern as other Note sections in the document

## Issue Details

- **Issue:** Note section doesn't expand in Step 4
- **Location:** https://apim.docs.wso2.com/en/latest/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-simple-scalable-setup/
- **Version:** 4.5.0
- **Issue URL:** https://github.com/ranuka-laksika/docs-apim/issues/4

## Test Plan

- [x] Verified the markdown formatting follows MkDocs admonition syntax
- [x] Confirmed consistency with other Note sections in the same document
- [x] Checked that the indentation uses 4 spaces as per MkDocs standards

The Note section should now render properly when the documentation is built.

Fixes #4