### PR TITLE
Fix Note section indentation in distributed deployment documentation

### DIFF
--- a/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-simple-scalable-setup.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-simple-scalable-setup.md
@@ -59,7 +59,7 @@ For more information, see [Production Deployment Guidelines](../../../../install
 Create an SSL certificate for each of the WSO2 API-M nodes and import them to the keystore and the truststore. This ensures that hostname mismatch issues in the certificates will not occur.
 
 !!! Note
-The same primary keystore should be used for all API Manager instances to decrypt the registry resources. For more information, see [Configuring the Primary Keystore](../../../../install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager/#configuring-the-primary-keystore).
+    The same primary keystore should be used for all API Manager instances to decrypt the registry resources. For more information, see [Configuring the Primary Keystore](../../../../install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager/#configuring-the-primary-keystore).
 
 For more information, see [Creating SSL Certificates](../../../../install-and-setup/setup/security/configuring-keystores/keystore-basics/creating-new-keystores/).
 


### PR DESCRIPTION
## Summary
- Fixed Note section indentation issue in Step 4 of distributed deployment documentation
- Added proper 4-space indentation to Note section content to ensure proper MkDocs admonition rendering
- The Note section now expands correctly when viewing the documentation

## Changes Made
- Modified `en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-simple-scalable-setup.md`
- Added 4-space indentation to the content under the Note admonition in Step 4

## Issue Resolved
Fixes issue #4: "Note Section doesn't expand" in the distributed deployment documentation.

## Test Plan
- [x] Verified the markdown syntax follows MkDocs admonition standards
- [x] Confirmed the indentation is correct (4 spaces as required by MkDocs)
- [ ] Documentation renders correctly with mkdocs serve (skipped due to dependency issues)

🤖 Generated with AI Agent