### PR TITLE
Fix broken SaaS link in deployment options - Issue #16

### DIFF
--- a/en/docs/index.md
+++ b/en/docs/index.md
@@ -300,7 +300,7 @@ template: templates/single-column.html
         "links": [
             {"name": "Deploy on VM", "url": "install-and-setup/install/installing-the-product/running-the-api-m/"},
             {"name": "Deploy on Kubernetes", "url": "install-and-setup/install/deploying-api-manager-with-kubernetes-resources/"},
-            {"name": "SaaS", "url": "https://wso2.com/bijira/"}
+            {"name": "SaaS", "url": "https://wso2.com/choreo/"}
         ]
     }],
     [{


### PR DESCRIPTION
## Summary
- Fixed broken SaaS link in deployment options section
- Replaced incorrect bijira link (https://wso2.com/bijira/) with proper Choreo link (https://wso2.com/choreo/)
- Issue was in en/docs/index.md line 303

## Test plan
- [x] Verified the link is correctly updated in the code
- [x] Link now points to the appropriate WSO2 Choreo page

Fixes #16

🤖 Generated with [Claude Code](https://claude.ai/code)