### PR TITLE
Fix HTTP to HTTPS URL in pull request template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -32,7 +32,7 @@
    > Details about the test cases and coverage
 
 ## Security checks
- - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
+ - Followed secure coding standards in https://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
  - Ran FindSecurityBugs plugin and verified report? yes/no
  - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no
 


### PR DESCRIPTION
## Summary
- Fixed HTTP URL to HTTPS in pull_request_template.md
- Changed http://wso2.com/technical-reports/wso2-secure-engineering-guidelines to https://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- Resolves build process failures caused by HTTP URLs

## Fixes
- Resolves issue #24

## Test plan
- [x] Verified the HTTPS URL is accessible and functional
- [x] Confirmed the change addresses the build failure issue mentioned

🤖 Generated with [Claude Code](https://claude.ai/code)