### PR TITLE
Fix broken links in integration examples section

### DIFF
--- a/en/docs/integrate/integration-overview.md
+++ b/en/docs/integrate/integration-overview.md
@@ -493,8 +493,8 @@ Learn how to implement various integration use cases, deploy them in the Micro I
                         <li><a href="{{base_path}}/integrate/examples/rest_api_examples/publishing-a-swagger-api">Publishing a Custom Swagger Document</a></li>
                         <li>Handling Special Cases
                             <ul>
-                                <li><a href="{{base_path}}/integrate/examples/routing_examples/routing_based_on_headers/">Using GET with a Message Body</a></li>
-                                <li><a href="{{base_path}}/integrate/examples/routing_examples/routing_based_on_payloads/">Using POST with Empty Message Body</a></li>
+                                <li><a href="{{base_path}}/integrate/examples/rest_api_examples/special-cases/#get-request-with-a-message-body">Using GET with a Message Body</a></li>
+                                <li><a href="{{base_path}}/integrate/examples/rest_api_examples/special-cases/#using-post-with-an-empty-body">Using POST with Empty Message Body</a></li>
                                 <li><a href="{{base_path}}/integrate/examples/rest_api_examples/special-cases/#using-post-with-query-parameters">Using POST with Query Parameters</a></li>
                             </ul>
                         </li>


### PR DESCRIPTION
## Summary
- Fixed broken links for 'Using GET with a Message Body' and 'Using POST with Empty Message Body' in the integration examples section
- Both links now correctly point to the appropriate sections in special-cases.md file
- The 'Using POST with Query Parameters' link was already correct

## Resolves
Fixes #45

## Test plan
- [x] Verified that the target file (special-cases.md) exists in the correct location
- [x] Verified that the anchor links match the section headers in special-cases.md
- [x] Confirmed the links now point to the appropriate content sections

🤖 Generated with Claude Code