### PR TITLE
Fix broken links in Integration Overview page (Issue #45)

### DIFF
--- a/en/docs/integrate/integration-overview.md
+++ b/en/docs/integrate/integration-overview.md
@@ -493,8 +493,8 @@ Learn how to implement various integration use cases, deploy them in the Micro I
                         <li><a href="{{base_path}}/integrate/examples/rest_api_examples/publishing-a-swagger-api">Publishing a Custom Swagger Document</a></li>
                         <li>Handling Special Cases
                             <ul>
-                                <li><a href="{{base_path}}/integrate/examples/routing_examples/routing_based_on_headers/">Using GET with a Message Body</a></li>
-                                <li><a href="{{base_path}}/integrate/examples/routing_examples/routing_based_on_payloads/">Using POST with Empty Message Body</a></li>
+                                <li><a href="{{base_path}}/integrate/examples/rest_api_examples/special-cases/#get-request-with-a-message-body">Using GET with a Message Body</a></li>
+                                <li><a href="{{base_path}}/integrate/examples/rest_api_examples/special-cases/#using-post-with-an-empty-body">Using POST with Empty Message Body</a></li>
                                 <li><a href="{{base_path}}/integrate/examples/rest_api_examples/special-cases/#using-post-with-query-parameters">Using POST with Query Parameters</a></li>
                             </ul>
                         </li>


### PR DESCRIPTION
## Summary
Fixed three broken links in the Integration Overview page that were causing 404 errors:

- **Using GET with a Message Body**: Fixed link to point to `rest_api_examples/special-cases.md#get-request-with-a-message-body`
- **Using POST with Empty Message Body**: Fixed link to point to `rest_api_examples/special-cases.md#using-post-with-an-empty-body`
- **Using POST with Query Parameters**: Link was already correct, pointing to `rest_api_examples/special-cases.md#using-post-with-query-parameters`

All three links now correctly point to the special-cases.md file in the REST API examples section, where the actual content for these special cases is documented.

## Changes Made
- Updated `en/docs/integrate/integration-overview.md` lines 496-497
- Changed incorrect routing_examples links to the correct rest_api_examples/special-cases links

## Testing
- Verified that the target special-cases.md file exists and contains the appropriate content
- Links now point to the correct sections within the special-cases documentation

Fixes #45

🤖 Generated with [Claude Code](https://claude.ai/code)