### PR TITLE
Fix HTTP URL to HTTPS in Custom JWT Generator sample

### DIFF
--- a/en/docs/administer/managing-users-and-roles/managing-user-stores/writing-a-custom-user-store-manager.md
+++ b/en/docs/administer/managing-users-and-roles/managing-user-stores/writing-a-custom-user-store-manager.md
@@ -274,7 +274,7 @@ To set up this implementation, do the following.
             <repository>
                 <id>wso2-nexus</id>
                 <name>WSO2 internal Repository</name>
-                <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+                <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
                 <releases>
                     <enabled>true</enabled>
                     <updatePolicy>daily</updatePolicy>


### PR DESCRIPTION
## Summary
- Fixed HTTP URL to HTTPS for WSO2 Maven repository in Custom JWT Generator sample
- Changed `http://maven.wso2.org/nexus/content/groups/wso2-public/` to `https://maven.wso2.org/nexus/content/groups/wso2-public/`
- Addresses security concern about using HTTP URLs for repository access

## Issue Fixed
Fixes #24

## Test Plan
- [x] Verified HTTPS URL syntax is correct
- [x] Confirmed change is limited to repository URL only
- [x] Documentation builds successfully

🤖 Generated with [Claude Code](https://claude.ai/code)