### PR TITLE
Fix HTTP URL to HTTPS in WSO2 Maven repository reference

### DIFF
--- a/en/docs/administer/managing-users-and-roles/managing-user-stores/writing-a-custom-user-store-manager.md
+++ b/en/docs/administer/managing-users-and-roles/managing-user-stores/writing-a-custom-user-store-manager.md
@@ -274,7 +274,7 @@ To set up this implementation, do the following.
             <repository>
                 <id>wso2-nexus</id>
                 <name>WSO2 internal Repository</name>
-                <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+                <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
                 <releases>
                     <enabled>true</enabled>
                     <updatePolicy>daily</updatePolicy>


### PR DESCRIPTION
## Summary
• Fixed insecure HTTP URL to HTTPS in CustomUserStoreManager pom.xml documentation
• Changed http://maven.wso2.org/nexus/ to https://maven.wso2.org/nexus/
• Resolves build process failures mentioned in issue #24

## Problem
The CustomUserStoreManager sample documentation contained an insecure HTTP URL reference to the WSO2 internal Maven repository, which causes build process failures when attempting to resolve dependencies.

## Solution
Updated the repository URL to use HTTPS protocol, ensuring secure and reliable artifact retrieval during Maven builds.

## Test plan
- [x] Verified WSO2 Maven repository supports HTTPS connections
- [x] Updated repository URL in pom.xml example
- [x] Confirmed URL structure remains valid with HTTPS protocol

🤖 Generated with [Claude Code](https://claude.ai/code)