### PR TITLE
Fix broken links in Integration Examples section

### DIFF
--- a/en/docs/integrate/integration-overview.md
+++ b/en/docs/integrate/integration-overview.md
@@ -493,8 +493,8 @@ Learn how to implement various integration use cases, deploy them in the Micro I
                         <li><a href="{{base_path}}/integrate/examples/rest_api_examples/publishing-a-swagger-api">Publishing a Custom Swagger Document</a></li>
                         <li>Handling Special Cases
                             <ul>
-                                <li><a href="{{base_path}}/integrate/examples/routing_examples/routing_based_on_headers/">Using GET with a Message Body</a></li>
-                                <li><a href="{{base_path}}/integrate/examples/routing_examples/routing_based_on_payloads/">Using POST with Empty Message Body</a></li>
+                                <li><a href="{{base_path}}/integrate/examples/rest_api_examples/special-cases/#get-request-with-a-message-body">Using GET with a Message Body</a></li>
+                                <li><a href="{{base_path}}/integrate/examples/rest_api_examples/special-cases/#using-post-with-an-empty-body">Using POST with Empty Message Body</a></li>
                                 <li><a href="{{base_path}}/integrate/examples/rest_api_examples/special-cases/#using-post-with-query-parameters">Using POST with Query Parameters</a></li>
                             </ul>
                         </li>

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -183,7 +183,7 @@ nav:
                 - Obtain User Profile Information with OpenID Connect: design/api-security/openid-connect/obtaining-user-profile-information-with-openid-connect.md
             - Open Policy Agent (OPA) Validation:
                 - Overview: design/api-security/opa-validation/overview.md
-                - Custom OPA Policy for Regualr Gateway: design/api-security/opa-validation/custom-opa-policy-for-regular-gateway.md
+                - Custom OPA Policy for Regular Gateway: design/api-security/opa-validation/custom-opa-policy-for-regular-gateway.md
                 - Custom OPA Policy for Choreo Connect: design/api-security/opa-validation/custom-opa-policy-for-choreo-connect.md
         - Rate Limiting:
                 - Throttling Use-Cases: design/rate-limiting/introducing-throttling-use-cases.md


### PR DESCRIPTION
## Summary
Fixed broken links in the Integration Examples section of integration-overview.md that were incorrectly pointing to routing examples instead of the special-cases documentation.

## Changes Made
- Fixed 'Using GET with a Message Body' link to point to   
- Fixed 'Using POST with Empty Message Body' link to point to 
- Verified 'Using POST with Query Parameters' link is correctly pointing to 

## Test plan
- [x] Links now correctly point to the appropriate sections in special-cases.md
- [x] All anchor links match the actual section headers in the target file
- [ ] Verify links work correctly when documentation is built and served

Resolves #45