### PR TITLE
Fix broken internal links in Kubernetes deployment pattern files

### DIFF
--- a/en/docs/install-and-setup/setup/kubernetes-deployment/am-pattern-0-all-in-one.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/am-pattern-0-all-in-one.md
@@ -5,7 +5,7 @@ This deployment consists of a single API-M node with a single API-M runtime. You
 <a href="{{base_path}}/assets/img/setup-and-install/single-node-apim-deployment.png"><img src="{{base_path}}/assets/img/setup-and-install/single-node-apim-deployment.png" width="70%" alt="single-node api-m deployment"></a>
 
 !!! info
-    For advanced details on the deployment pattern, please refer to the official [documentation](kubernetes-deployment-overview.md).
+    For advanced details on the deployment pattern, please refer to the official [documentation](kubernetes-overview.md).
 
 ## Contents
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/am-pattern-1-all-in-one-ha.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/am-pattern-1-all-in-one-ha.md
@@ -5,7 +5,7 @@ This deployment consists of a highly available API-M cluster with multiple nodes
 <a href="{{base_path}}/assets/img/setup-and-install/active-active-apim-deployment.png"><img src="{{base_path}}/assets/img/setup-and-install/active-active-apim-deployment.png" width="70%" alt="active-active apim deployment"></a>
 
 !!! info
-    For advanced details on this deployment pattern, please refer to the official [documentation](kubernetes-deployment-overview.md).
+    For advanced details on this deployment pattern, please refer to the official [documentation](kubernetes-overview.md).
 
 ## Contents
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/am-pattern-2-all-in-one-gw.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/am-pattern-2-all-in-one-gw.md
@@ -5,7 +5,7 @@ This is the standard distributed deployment for API Manager. The default configu
 <a href="{{base_path}}/assets/img/setup-and-install/deployment-no-tm.png"><img src="{{base_path}}/assets/img/setup-and-install/deployment-no-tm.png" alt="simple scalable api-m deployment" width="60%"></a>
 
 !!! info
-    For advanced details on the deployment pattern, please refer to the official [documentation](kubernetes-deployment-overview.md).
+    For advanced details on the deployment pattern, please refer to the official [documentation](kubernetes-overview.md).
 
 ## Contents
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/am-pattern-3-acp-tm-gw.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/am-pattern-3-acp-tm-gw.md
@@ -5,7 +5,7 @@ This is the standard distributed deployment for API Manager. The default configu
 <a href="{{base_path}}/assets/img/setup-and-install/distributed-deployment-tm.png"><img src="{{base_path}}/assets/img/setup-and-install/distributed-deployment-tm.png" alt="simple scalable api-m deployment" width="60%"></a>
 
 For advanced details on the deployment pattern, please refer to the official
-[documentation](kubernetes-deployment-overview.md).
+[documentation](kubernetes-overview.md).
 
 ## Contents
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/am-pattern-4-acp-tm-gw-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/am-pattern-4-acp-tm-gw-km.md
@@ -5,7 +5,7 @@ This is the fully distributed deployment for API Manager. The default configurat
 <a href="{{base_path}}/assets/img/setup-and-install/distributed-deployment-km.png"><img src="{{base_path}}/assets/img/setup-and-install/distributed-deployment-km.png" alt="fully distributed deployment" width="60%"></a>
 
 !!! info
-    For advanced details on the deployment pattern, please refer to the official [documentation](kubernetes-deployment-overview.md).
+    For advanced details on the deployment pattern, please refer to the official [documentation](kubernetes-overview.md).
 
 ## Contents
 

--- a/en/docs/install-and-setup/setup/kubernetes-deployment/am-pattern-5-all-in-one-gw-km.md
+++ b/en/docs/install-and-setup/setup/kubernetes-deployment/am-pattern-5-all-in-one-gw-km.md
@@ -13,7 +13,7 @@ This document provides step-by-step instructions to deploy WSO2 API Manager in a
 <a href="{{base_path}}/assets/img/setup-and-install/deployment-km.png"><img src="{{base_path}}/assets/img/setup-and-install/deployment-km.png" alt="Simple Scalable Deployment" width="100%"></a>
 
 !!! tip
-    For advanced details on this deployment pattern, please refer to the official [WSO2 API Manager documentation](kubernetes-deployment-overview.md).
+    For advanced details on this deployment pattern, please refer to the official [WSO2 API Manager documentation](kubernetes-overview.md).
 
 ## Contents
 


### PR DESCRIPTION
## Summary
- Fixed broken internal links in 6 Kubernetes deployment pattern files
- Updated references from non-existent `kubernetes-deployment-overview.md` to existing `kubernetes-overview.md`
- All links now correctly point to the Kubernetes prerequisites and deployment overview documentation

## Files Modified
- `am-pattern-0-all-in-one.md`
- `am-pattern-1-all-in-one-ha.md`
- `am-pattern-2-all-in-one-gw.md`
- `am-pattern-3-acp-tm-gw.md`
- `am-pattern-4-acp-tm-gw-km.md`  
- `am-pattern-5-all-in-one-gw-km.md`

## Test plan
- [x] Verified target file `kubernetes-overview.md` exists and contains valid content
- [x] Confirmed all 6 files now reference the correct link
- [x] Verified no broken links remain in the updated files

Resolves: #62

🤖 Generated with [Claude Code](https://claude.ai/code)