### PR TITLE
Fix systematic spelling and grammar errors in API Manager documentation

### DIFF
--- a/en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/migrating-api-products-to-different-environments.md
+++ b/en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/migrating-api-products-to-different-environments.md
@@ -193,7 +193,7 @@ apiIdentifier:
         </tr>
         <tr class="odd">
             <td>Docs</td>
-            <td> This folder will contain documentation attached to a particular API Product. Each document will have a seperate folder by its name. Each folder will contain a file named <code>document.yaml</code> which will contain the meta information related to a document. Example for a <code>document.yaml</code> file is shown below.
+            <td> This folder will contain documentation attached to a particular API Product. Each document will have a separate folder by its name. Each folder will contain a file named <code>document.yaml</code> which will contain the meta information related to a document. Example for a <code>document.yaml</code> file is shown below.
             <pre><code>
 type: document
 version: v4.4.0

--- a/en/docs/install-and-setup/setup/distributed-deployment/configuring-apim-as-a-gateway.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/configuring-apim-as-a-gateway.md
@@ -4,7 +4,7 @@
 
 The Control Plane serves as the central intelligence hub for WSO2 APK, orchestrating the entirety of the API ecosystem. It encompasses critical functionalities such as API management, administrative operations, and the API marketplace. Structurally, it comprises four principal components: the Back Office, Dev Portal, Admin Portal, and APIM-APK Agent. These components cater to diverse user roles, ranging from API product managers to consumers and administrative personnel. Within the Control Plane, users configure, oversee, and track the performance of APIs, ensuring seamless management and optimization of the API landscape.
 
-For the APK Control Plane, we are going to use same WSO2 API Manager Control Plane. The WSO2 API Manager control plane is a set of components that are responsible for managing and monitoring APIs.
+For the APK Control Plane, we are going to use the same WSO2 API Manager Control Plane. The WSO2 API Manager control plane is a set of components that are responsible for managing and monitoring APIs.
 APK Only supports REST API and GraphQL API creation for now.
 
 ## Architecture
@@ -17,8 +17,8 @@ Following diagram depicts the architecture of how the WSO2 APIM Control Plane co
 
 The APIM APK Agent is a component that connects the WSO2 API Manager (APIM) control plane with the WSO2 APK Gateway. The APIM APK Agent is responsible for the following tasks:
 
-- Recieve JMS Events which relates to API,Application,Subscription management from the APIM Control Plane.
-- Convert the data which is recieved from the APIM Control Plane to the APK Gateway understandable format which are K8s Custom Resources.
+- Receive JMS Events which relate to API, Application, Subscription management from the APIM Control Plane.
+- Convert the data which is received from the APIM Control Plane to the APK Gateway understandable format which are K8s Custom Resources.
 - Apply the generated Custom Resources to the K8s cluster to deploy API to APK Gateway.
 
 ## Supported Features

--- a/en/docs/reference/customize-product/customizations/customizing-the-developer-portal/overriding-developer-portal-theme.md
+++ b/en/docs/reference/customize-product/customizations/customizing-the-developer-portal/overriding-developer-portal-theme.md
@@ -126,7 +126,7 @@ The following documents describe some of the most commonly used customizations, 
     ```
     
     The default theme configuration can be found at `<APIM_HOME>/repository/deployment/server/webapps/devportal/source/src/app/data/defaultTheme.js`. 
-    In the shared defaultTheme.json we have overriden the `custom.appBar` configurations only.
+    In the shared defaultTheme.json we have overridden the `custom.appBar` configurations only.
     
     ```
     {

--- a/en/docs/reference/product-apis/admin-apis/admin-v4/admin-v4.yaml
+++ b/en/docs/reference/product-apis/admin-apis/admin-v4/admin-v4.yaml
@@ -2067,7 +2067,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/PublishStatus'
         202:
-          description: Request is sucessfully accepted for processing.
+          description: Request is successfully accepted for processing.
           content:
             application/json:
               schema:
@@ -4378,12 +4378,12 @@ components:
           properties:
             dataAmount:
               type: integer
-              description: Amount of data allowed to be transfered
+              description: Amount of data allowed to be transferred
               format: int64
               example: 1000
             dataUnit:
               type: string
-              description: Unit of data allowed to be transfered. Allowed values are
+              description: Unit of data allowed to be transferred. Allowed values are
                 "KB", "MB" and "GB"
               example: KB
     RequestCountLimit:

--- a/en/docs/reference/product-apis/devportal-apis/devportal-v3/devportal-v3.yaml
+++ b/en/docs/reference/product-apis/devportal-apis/devportal-v3/devportal-v3.yaml
@@ -774,7 +774,7 @@ paths:
         2. **FILE type**:
            The file will be downloaded with the related content type (eg. `application/pdf`)
         3. **URL type**:
-            The client will recieve the URL of the document as the Location header with the response with - `303 See Other`
+            The client will receive the URL of the document as the Location header with the response with - `303 See Other`
 
         `X-WSO2-Tenant` header can be used to retrive the content of a document of an API that belongs to a different tenant domain. If not specified super tenant will be used. If Authorization header is present in the request, the user's tenant associated with the access token will be used.
 
@@ -4547,7 +4547,7 @@ components:
           example: 50
         dataUnit:
           description: |
-            Unit of data allowed to be transfered. Allowed values are "KB", "MB" and "GB"
+            Unit of data allowed to be transferred. Allowed values are "KB", "MB" and "GB"
           type: string
           example: KB
         unitTime:

--- a/en/docs/reference/product-apis/publisher-apis/publisher-v4/publisher-v4.yaml
+++ b/en/docs/reference/product-apis/publisher-apis/publisher-v4/publisher-v4.yaml
@@ -68,7 +68,7 @@ info:
     of this document and scope for each resource is given in **authorization** section of resource documentation.
     Following is the format of the request if you are using the password grant type.
     ```
-    curl -k -d "grant_type=password&username=<admin_username>&password=<admin_passowrd&scope=<scopes seperated by space>"
+    curl -k -d "grant_type=password&username=<admin_username>&password=<admin_passowrd&scope=<scopes separated by space>"
     \ -H "Authorization: Basic base64(cliet_id:client_secret)"
     \ https://<host>:<servlet_port>/oauth2/token
     ```
@@ -3487,7 +3487,7 @@ paths:
         2. **FILE type**:
            The file will be downloaded with the related content type (eg. `application/pdf`)
         3. **URL type**:
-            The client will recieve the URL of the document as the Location header with the response with - `303 See Other`
+            The client will receive the URL of the document as the Location header with the response with - `303 See Other`
       parameters:
         - $ref: '#/components/parameters/apiId'
         - $ref: '#/components/parameters/documentId'
@@ -3640,7 +3640,7 @@ paths:
         - name: name
           in: query
           description: |
-            The name of the document which needs to be checked for the existance.
+            The name of the document which needs to be checked for the existence.
           required: true
           schema:
             type: string
@@ -6665,7 +6665,7 @@ paths:
         2. **FILE type**:
            The file will be downloaded with the related content type (eg. `application/pdf`)
         3. **URL type**:
-            The client will recieve the URL of the document as the Location header with the response with - `303 See Other`
+            The client will receive the URL of the document as the Location header with the response with - `303 See Other`
       parameters:
         - $ref: '#/components/parameters/apiProductId'
         - $ref: '#/components/parameters/documentId'
@@ -11366,7 +11366,7 @@ components:
           example: 50
         dataUnit:
           description: |
-            Unit of data allowed to be transfered. Allowed values are "KB", "MB" and "GB"
+            Unit of data allowed to be transferred. Allowed values are "KB", "MB" and "GB"
           type: string
           example: KB
         totalTokenCount:
@@ -11608,12 +11608,12 @@ components:
           properties:
             dataAmount:
               type: integer
-              description: Amount of data allowed to be transfered
+              description: Amount of data allowed to be transferred
               format: int64
               example: 1000
             dataUnit:
               type: string
-              description: Unit of data allowed to be transfered. Allowed values are
+              description: Unit of data allowed to be transferred. Allowed values are
                 "KB", "MB" and "GB"
               example: KB
     RequestCountLimit:
@@ -13316,7 +13316,7 @@ components:
         delimiter:
           type: string
           description: |
-            delimiter to seperate the email address
+            delimiter to separate the email address
     MonetizationAttribute:
       title: Monetization attribute object
       type: object

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -511,7 +511,7 @@ nav:
                             - Work with Encrypted Passwords: install-and-setup/setup/security/logins-and-passwords/working-with-encrypted-passwords.md
                             - Set Up ReCaptcha: install-and-setup/setup/security/logins-and-passwords/setting-up-recaptcha.md
                             - Configure reCaptcha for Single Sign On : install-and-setup/setup/security/logins-and-passwords/configuring-recaptcha-for-single-sign-on.md
-                            - Intergrate with HashiCorp Vault : install-and-setup/setup/security/logins-and-passwords/harshicrop-vault-extension.md
+                            - Integrate with HashiCorp Vault : install-and-setup/setup/security/logins-and-passwords/harshicrop-vault-extension.md
                     - Configure Keystores:
                         - Configure Keystores in API Manager: install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager.md
                         - Keystore Basics:


### PR DESCRIPTION
This PR addresses systematic spelling and grammar errors found throughout the WSO2 API Manager documentation as described in issue #60.

## Summary
- Fixed spelling errors: Intergrate → Integrate, recieve → receive, existance → existence, transfered → transferred, seperate → separate, sucessfully → successfully, overriden → overridden  
- Fixed grammar errors: subject-verb agreement and article usage
- Improved spacing and punctuation consistency
- Updated 7 files across API documentation and configuration

## Files Modified
- `en/mkdocs.yml` - Fixed "Intergrate" to "Integrate" 
- `en/docs/reference/product-apis/publisher-apis/publisher-v4/publisher-v4.yaml` - Multiple spelling corrections
- `en/docs/reference/product-apis/admin-apis/admin-v4/admin-v4.yaml` - Spelling corrections  
- `en/docs/reference/product-apis/devportal-apis/devportal-v3/devportal-v3.yaml` - Spelling corrections
- `en/docs/reference/customize-product/customizations/customizing-the-developer-portal/overriding-developer-portal-theme.md` - Fixed "overriden" to "overridden"
- `en/docs/install-and-setup/setup/api-controller/managing-apis-api-products/migrating-api-products-to-different-environments.md` - Fixed "seperate" to "separate"  
- `en/docs/install-and-setup/setup/distributed-deployment/configuring-apim-as-a-gateway.md` - Multiple corrections including grammar fixes

## Test plan
- [ ] Documentation builds successfully with MkDocs
- [ ] All corrected spellings are accurate
- [ ] Grammar improvements enhance readability
- [ ] No functional changes to code or configurations

🤖 Generated with [Claude Code](https://claude.ai/code)