### PR TITLE
Fix spelling errors in WSO2 API Manager 4.5.0 documentation

### DIFF
--- a/en/docs/index.md
+++ b/en/docs/index.md
@@ -525,7 +525,7 @@ template: templates/single-column.html
                                     </div>
                                 </div>
                                 <hr/>
-                                <p class="removeTopMargin">Manage APIs spaning multiple cloud platforms, on-premises systems, or regions</p>
+                                <p class="removeTopMargin">Manage APIs spanning multiple cloud platforms, on-premises systems, or regions</p>
                                 <div>
                                     <ul>
                                         <li><a href="{{base_path}}/manage-apis/deploy-and-publish/deploy-on-gateway/federated-gateways/deploy-on-aws-api-gateway/">AWS API Gateway</a></li>

--- a/en/docs/install-and-setup/install-and-setup-overview.md
+++ b/en/docs/install-and-setup/install-and-setup-overview.md
@@ -88,7 +88,7 @@ To set up the API Manager component, see the following topics.
     <th>
         <a>Setting up Proxy Server and the Load Balancer
     <td>
-        A load balancer or reverse proxy is required to map external traffic with ports and URLs that the APi Manager component uses internally. This section covers the following topics relating to the proxy server and the load balancer.
+        A load balancer or reverse proxy is required to map external traffic with ports and URLs that the API Manager component uses internally. This section covers the following topics relating to the proxy server and the load balancer.
         <ul>
             <li>
                 <a href="{{base_path}}/install-and-setup/setup/setting-up-proxy-server-and-the-load-balancer/configuring-the-proxy-server-and-the-load-balancer">Configuring the Proxy Server and the Load Balancer</a>
@@ -140,7 +140,7 @@ To set up the API Manager component, see the following topics.
                         <a href="{{base_path}}/install-and-setup/setup/security/configuring-keystores/keystore-basics/renewing-a-ca-signed-certificate-in-a-keystore">Renewing a CA Signed Certificate</a>
                     </li>
                     <li>
-                        <a href="{{base_path}}/install-and-setup/setup/security/configuring-keystores/keystore-basics/about-asymetric-cryptography">About Asymetric Cryptography</a>
+                        <a href="{{base_path}}/install-and-setup/setup/security/configuring-keystores/keystore-basics/about-asymetric-cryptography">About Asymmetric Cryptography</a>
                     </li>
             <li>
                 <a href="{{base_path}}/install-and-setup/setup/security/enabling-hostname-verification">Enabling HostName Verification</a>
@@ -387,7 +387,7 @@ To upgrade to the current API Manager component from a previous version refer [U
             <a href="{{base_path}}/install-and-setup/setup/reference/default-product-ports">Default Product Ports</a>
         </th>
         <td>
-            Explains the defauly ports used by the API Manager component.
+            Explains the default ports used by the API Manager component.
         </td>
     </tr>
     <tr>

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -591,7 +591,7 @@ nav:
                         - Keystore Basics:
                             - Create a New Keystore: install-and-setup/setup/security/configuring-keystores/keystore-basics/creating-new-keystores.md
                             - Renew a CA Signed Certificate: install-and-setup/setup/security/configuring-keystores/keystore-basics/renewing-a-ca-signed-certificate-in-a-keystore.md
-                            - About Asymetric Cryptography: install-and-setup/setup/security/configuring-keystores/keystore-basics/about-asymetric-cryptography.md
+                            - About Asymmetric Cryptography: install-and-setup/setup/security/configuring-keystores/keystore-basics/about-asymetric-cryptography.md
                     - Enable HostName Verification: install-and-setup/setup/security/enabling-hostname-verification.md
                     - Enable Java Security Manager: install-and-setup/setup/security/enabling-java-security-manager.md
                     - General Data Protection Regulation (GDPR) for WSO2 API Manager: install-and-setup/setup/security/general-data-protection-regulation-gdpr-for-wso2-api-manager.md


### PR DESCRIPTION
## Summary
- Fixed 'spaning' → 'spanning' in index.md line 528
- Fixed 'defauly' → 'default' in install-and-setup-overview.md line 390
- Fixed 'APi' → 'API' in install-and-setup-overview.md line 91
- Fixed 'Asymetric' → 'Asymmetric' in install-and-setup-overview.md line 143 and mkdocs.yml

## Changes Made
This PR addresses issue #128 by correcting 4 spelling errors across 3 files in the WSO2 API Manager 4.5.0 documentation:

1. **index.md**: Fixed 'spaning' to 'spanning' in the Federated Gateways description
2. **install-and-setup-overview.md**: Fixed three spelling errors:
   - 'defauly' to 'default' in Default Product Ports description
   - 'APi' to 'API' in Proxy Server section
   - 'Asymetric' to 'Asymmetric' in Keystores section
3. **mkdocs.yml**: Fixed 'Asymetric' to 'Asymmetric' in navigation menu

## Test plan
- [x] Verified spelling corrections in all affected files
- [x] Confirmed no additional spelling errors remain
- [x] Changes improve documentation professional quality
- [x] All changes are minimal and focused on spelling only

🤖 Generated with [Claude Code](https://claude.ai/code)