### PR TITLE
Fix Note section indentation under Step 4 (v4.6.0)

### DIFF
--- a/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-simple-scalable-setup.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-simple-scalable-setup.md
@@ -59,7 +59,7 @@ For more information, see [Production Deployment Guidelines](../../../../install
 Create an SSL certificate for each of the WSO2 API-M nodes and import them to the keystore and the truststore. This ensures that hostname mismatch issues in the certificates will not occur.
 
 !!! Note
-The same primary keystore should be used for all API Manager instances to decrypt the registry resources. For more information, see [Configuring the Primary Keystore](../../../../install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager/#configuring-the-primary-keystore).
+    The same primary keystore should be used for all API Manager instances to decrypt the registry resources. For more information, see [Configuring the Primary Keystore](../../../../install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager/#configuring-the-primary-keystore).
 
 For more information, see [Creating SSL Certificates](../../../../install-and-setup/setup/security/configuring-keystores/keystore-basics/creating-new-keystores/).
 


### PR DESCRIPTION
## Summary
- Fixed the indentation issue for the Note section under Step 4 in the distributed deployment guide for version 4.6.0
- The Note content is now properly indented with 4 spaces under the !!! Note directive  
- This allows the admonition block to expand correctly in the rendered documentation

## Test plan
- [x] Verified the markdown syntax is correct
- [x] Confirmed the Note section now has proper 4-space indentation
- [x] Added missing newline at end of file

Related to #4 (same issue found in version 4.6.0)

🤖 Generated with [Claude Code](https://claude.ai/code)