### PR TITLE
Fix spelling mistakes in documentation for v4.4.0 - Issue #128

### DIFF
--- a/en/docs/install-and-setup/install-and-setup-overview.md
+++ b/en/docs/install-and-setup/install-and-setup-overview.md
@@ -88,7 +88,7 @@ To set up the API Manager component, see the following topics.
     <th>
         <a>Setting up Proxy Server and the Load Balancer
     <td>
-        A load balancer or reverse proxy is required to map external traffic with ports and URLs that the APi Manager component uses internally. This section covers the following topics relating to the proxy server and the load balancer.
+        A load balancer or reverse proxy is required to map external traffic with ports and URLs that the API Manager component uses internally. This section covers the following topics relating to the proxy server and the load balancer.
         <ul>
             <li>
                 <a href="{{base_path}}/install-and-setup/setup/setting-up-proxy-server-and-the-load-balancer/configuring-the-proxy-server-and-the-load-balancer">Configuring the Proxy Server and the Load Balancer</a>
@@ -140,7 +140,7 @@ To set up the API Manager component, see the following topics.
                         <a href="{{base_path}}/install-and-setup/setup/security/configuring-keystores/keystore-basics/renewing-a-ca-signed-certificate-in-a-keystore">Renewing a CA Signed Certificate</a>
                     </li>
                     <li>
-                        <a href="{{base_path}}/install-and-setup/setup/security/configuring-keystores/keystore-basics/about-asymetric-cryptography">About Asymetric Cryptography</a>
+                        <a href="{{base_path}}/install-and-setup/setup/security/configuring-keystores/keystore-basics/about-asymmetric-cryptography">About Asymmetric Cryptography</a>
                     </li>
             <li>
                 <a href="{{base_path}}/install-and-setup/setup/security/enabling-hostname-verification">Enabling HostName Verification</a>
@@ -395,7 +395,7 @@ To upgrade to the current API Manager component from a previous version refer [U
             <a href="{{base_path}}/install-and-setup/setup/reference/default-product-ports">Default Product Ports</a>
         </th>
         <td>
-            Explains the defauly ports used by the API Manager component.
+            Explains the default ports used by the API Manager component.
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
## Summary

Fixed spelling mistakes in WSO2 API Manager 4.4.0 documentation as reported in issue #128:

### Changes Made:
- **install-and-setup-overview.md**: 
  - Fixed 'APi Manager' → 'API Manager' (line 91)
  - Fixed 'Asymetric Cryptography' → 'Asymmetric Cryptography' (line 143, both text and URL)
  - Fixed 'defauly' → 'default' (line 398)

### Files Modified:
- en/docs/install-and-setup/install-and-setup-overview.md

### Test Results:
✅ MkDocs build passes successfully
✅ All spelling errors corrected  
✅ No functional changes, only typography fixes

## Test Plan
- [x] Verify all spelling corrections are accurate
- [x] Confirm MkDocs builds without errors
- [x] Check that no functionality is affected
- [x] Validate all links and references remain intact

**Related Issue:** Fixes #128 (partial - version 4.4.0)