### PR TITLE
Fix Note Section Not Expandable - Issue #143

### DIFF
--- a/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-simple-scalable-setup.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-simple-scalable-setup.md
@@ -58,8 +58,8 @@ For more information, see [Production Deployment Guidelines](../../../../install
 
 Create an SSL certificate for each of the WSO2 API-M nodes and import them to the keystore and the truststore. This ensures that hostname mismatch issues in the certificates will not occur.
 
-!!! Note
-The same primary keystore should be used for all API Manager instances to decrypt the registry resources. For more information, see [Configuring the Primary Keystore](../../../../install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager/#configuring-the-primary-keystore).
+??? note
+    The same primary keystore should be used for all API Manager instances to decrypt the registry resources. For more information, see [Configuring the Primary Keystore](../../../../install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager/#configuring-the-primary-keystore).
 
 For more information, see [Creating SSL Certificates](../../../../install-and-setup/setup/security/configuring-keystores/keystore-basics/creating-new-keystores/).
 


### PR DESCRIPTION
## Summary
- Fixed non-expandable note section in Step 4 of SSL certificates documentation
- Changed syntax from `!!! Note` to `??? note` to make it collapsible/expandable
- Applied proper indentation for the content inside the collapsible note

## Changes Made
- Updated `en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-simple-scalable-setup.md`
- Changed line 61-62: Static note to collapsible note using Material for MkDocs admonition syntax

## Test Plan
- [x] Verify the syntax change follows Material for MkDocs standards
- [x] Check that similar collapsible notes exist in other documentation files
- [x] Confirm the issue exists only in version 4.5.0 (not in 4.4.0)

Fixes #143

🤖 Generated with [Claude Code](https://claude.ai/code)