### PR TITLE
Grammar fix: Hyphenate 'cloud-native' compound adjective in v4.4.0

### DIFF
--- a/en/docs/install-and-setup/setup/deployment-best-practices/production-deployment-guidelines.md
+++ b/en/docs/install-and-setup/setup/deployment-best-practices/production-deployment-guidelines.md
@@ -128,7 +128,7 @@ Given below is a checklist that will guide you to set up your production environ
          <td>High availability</td>
          <td>
             <p>Configure your deployment with high availability. Refer the <a href="{{base_path}}/install-and-setup/setup/deployment-overview">recommended deployment patterns</a> and select an option that fits your requirements.</p>
-            <p>In the cloud native deployment, high availability should be achieved via the container orchestration system (Kubernetes).</p>
+            <p>In the cloud-native deployment, high availability should be achieved via the container orchestration system (Kubernetes).</p>
          </td>
       </tr>
       <tr class="even">

--- a/en/docs/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment.md
+++ b/en/docs/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment.md
@@ -366,7 +366,7 @@ This section provides a list of security guidelines for configuring the network
 <td><p>Create a failover setup</p>
 <p><br />
 </p></td>
-<td>In the cloud native deployment, high-availability should be achieved via the container orchestration system (e.g., Kubernetes ). 
+<td>In the cloud-native deployment, high-availability should be achieved via the container orchestration system (e.g., Kubernetes ). 
 <p>In a VM deployment, there should be at least two nodes with the failover configuration. When your servers are clustered, you need to regularly monitor the health of your server instances. For example, you need to monitor resource-level factors such as the server's resource utilization, response time anomalies, and the number of incoming network connections. Server monitoring will help you identify when additional server instances (failover instances) are required. You can also make decisions about network routing changes that you need to do in order to avoid server downtime.</p>
 </td>
 </tr>


### PR DESCRIPTION
## Changes Made
- Fixed 'cloud native deployment' to 'cloud-native deployment' in security guidelines file
- Fixed 'cloud native deployment' to 'cloud-native deployment' in production guidelines file  
- Applied proper English grammar rules for compound adjectives

## Files Changed
- `en/docs/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment.md`
- `en/docs/install-and-setup/setup/deployment-best-practices/production-deployment-guidelines.md`

## Issue Details
Fixes issue #150: Grammar improvements for compound adjectives in documentation

This PR follows WSO2 documentation standards and improves grammatical consistency.