### PR TITLE
Grammar fix: Hyphenate 'cloud-native' compound adjective in v4.5.0

### DIFF
--- a/en/docs/install-and-setup/setup/deployment-best-practices/production-deployment-guidelines.md
+++ b/en/docs/install-and-setup/setup/deployment-best-practices/production-deployment-guidelines.md
@@ -128,7 +128,7 @@ Given below is a checklist that will guide you to set up your production environ
          <td>High availability</td>
          <td>
             <p>Configure your deployment with high availability. Refer the <a href="{{base_path}}/install-and-setup/setup/deployment-overview">recommended deployment patterns</a> and select an option that fits your requirements.</p>
-            <p>In the cloud native deployment, high availability should be achieved via the container orchestration system (Kubernetes).</p>
+            <p>In the cloud-native deployment, high availability should be achieved via the container orchestration system (Kubernetes).</p>
          </td>
       </tr>
       <tr class="even">

--- a/en/docs/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment.md
+++ b/en/docs/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment.md
@@ -366,7 +366,7 @@ This section provides a list of security guidelines for configuring the network
 <td><p>Create a failover setup</p>
 <p><br />
 </p></td>
-<td>In the cloud native deployment, high-availability should be achieved via the container orchestration system (e.g., Kubernetes ). 
+<td>In the cloud-native deployment, high-availability should be achieved via the container orchestration system (e.g., Kubernetes ). 
 <p>In a VM deployment, there should be at least two nodes with the failover configuration. When your servers are clustered, you need to regularly monitor the health of your server instances. For example, you need to monitor resource-level factors such as the server's resource utilization, response time anomalies, and the number of incoming network connections. Server monitoring will help you identify when additional server instances (failover instances) are required. You can also make decisions about network routing changes that you need to do in order to avoid server downtime.</p>
 </td>
 </tr>

--- a/en/docs/tutorials/single-control-plane-for-multiple-gateways.md
+++ b/en/docs/tutorials/single-control-plane-for-multiple-gateways.md
@@ -20,19 +20,19 @@ In WSO2 API Manager, the API gateway is a critical component responsible for han
 Here are the three main API gateways in WSO2 API Manager:
 
 - **Universal Gateway**: This is the default, core API gateway that handles all incoming API traffic, processes requests according to policies defined in the control plane (like API security, throttling), and routes requests to backend services. The universal gateway is typically deployed as a standalone gateway in a single environment or as part of a larger distributed system in multiple regions or data centers.
-- **Kubernetes Gateway**: The cloud native gateway deployment option is designed for Kubernetes environments. It integrates with cloud native platforms, such as Kubernetes clusters, and leverages containers to manage API gateway deployments.
+- **Kubernetes Gateway**: The cloud-native gateway deployment option is designed for Kubernetes environments. It integrates with cloud-native platforms, such as Kubernetes clusters, and leverages containers to manage API gateway deployments.
 - **Immutable Gateway**: The WSO2 Microgateway is a lightweight, low-latency API gateway designed specifically for microservices-based architectures. It is designed to be used in environments where APIs are deployed in containerized or serverless setups. It is typically deployed as part of a microservices architecture where each service has its own gateway, running in isolated environments or as sidecars to microservices.
 
 For details on selecting the appropriate self-managed WSO2 API Gateway, refer to the [Choosing the Right Self-Managed WSO2 API Gateway for Your Needs](https://wso2.com/library/blogs/choosing-the-right-self-managed-wso2-api-gateway-for-your-needs/). This tutorial will offer a comprehensive guide for each gateway, explaining how to utilize the API control plane (ACP) to manage APIs deployed within them.
 
 ## WSO2’s Single Control Plane for Multiple Gateways
 
-A platform engineer must be able to manage APIs from a single WSO2 API Manager control plane. These APIs should be exposed through various gateway types (Universal, Kubernetes, and Immutable). This capability will enable support for diverse deployment targets, such as VMs, containers, and cloud native environments.
+A platform engineer must be able to manage APIs from a single WSO2 API Manager control plane. These APIs should be exposed through various gateway types (Universal, Kubernetes, and Immutable). This capability will enable support for diverse deployment targets, such as VMs, containers, and cloud-native environments.
 
 This setup enables:
 
 - Centralized API publishing and governance.
-- Deployment to multiple execution environments (on-prem, cloud native, and containerized).
+- Deployment to multiple execution environments (on-prem, cloud-native, and containerized).
 - Fine-grained control over exposure of APIs based on organizational or infrastructure needs.
 - Agility and scalability through appropriate use of each gateway type.
 


### PR DESCRIPTION
## Changes Made
- Fixed 'cloud native deployment' to 'cloud-native deployment' in security guidelines
- Fixed 'cloud native deployment' to 'cloud-native deployment' in production guidelines  
- Fixed multiple 'cloud native' instances to 'cloud-native' in tutorial documentation
- Applied proper English grammar rules for compound adjectives

## Files Changed
- `en/docs/install-and-setup/setup/deployment-best-practices/security-guidelines-for-production-deployment.md`
- `en/docs/install-and-setup/setup/deployment-best-practices/production-deployment-guidelines.md`
- `en/docs/tutorials/single-control-plane-for-multiple-gateways.md`

## Issue Details
Related to issue #150: Grammar improvements for compound adjectives in documentation

This PR follows WSO2 documentation standards and improves grammatical consistency across v4.5.0.