### PR TITLE
Fix spelling error: 'spaning' → 'spanning' in index.md (v4.6.0)

### DIFF
--- a/en/docs/index.md
+++ b/en/docs/index.md
@@ -525,7 +525,7 @@ template: templates/single-column.html
                                     </div>
                                 </div>
                                 <hr/>
-                                <p class="removeTopMargin">Manage APIs spaning multiple cloud platforms, on-premises systems, or regions</p>
+                                <p class="removeTopMargin">Manage APIs spanning multiple cloud platforms, on-premises systems, or regions</p>
                                 <div>
                                     <ul>
                                         <li><a href="{{base_path}}/deploy-and-publish/deploy-on-gateway/federated-gateways/deploy-on-aws-api-gateway/">AWS API Gateway</a></li>


### PR DESCRIPTION
## Summary
- Fixed spelling error in /en/docs/index.md
- Changed 'spaning' to 'spanning' in Federated Gateways description
- Improves documentation readability and professionalism

## Changes Made
- Line 528: 'Manage APIs spaning multiple cloud platforms' → 'Manage APIs spanning multiple cloud platforms'

## Test Plan
- [x] Verified spelling correction is accurate
- [x] Confirmed change matches issue requirements  
- [x] Change maintains WSO2 documentation standards

🤖 Generated with [Claude Code](https://claude.ai/code)