### PR TITLE
Fix note section expandability in distributed deployment docs (v4.6.0)

### DIFF
--- a/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-simple-scalable-setup.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-simple-scalable-setup.md
@@ -58,8 +58,8 @@ For more information, see [Production Deployment Guidelines](../../../../install
 
 Create an SSL certificate for each of the WSO2 API-M nodes and import them to the keystore and the truststore. This ensures that hostname mismatch issues in the certificates will not occur.
 
-!!! Note
-The same primary keystore should be used for all API Manager instances to decrypt the registry resources. For more information, see [Configuring the Primary Keystore](../../../../install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager/#configuring-the-primary-keystore).
+??? note
+    The same primary keystore should be used for all API Manager instances to decrypt the registry resources. For more information, see [Configuring the Primary Keystore](../../../../install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager/#configuring-the-primary-keystore).
 
 For more information, see [Creating SSL Certificates](../../../../install-and-setup/setup/security/configuring-keystores/keystore-basics/creating-new-keystores/).
 
@@ -189,7 +189,7 @@ Follow the instructions given below to configure the Gateway node so that it can
 
 5. Add the public certificate of the private key (that is used for signing the tokens) to the truststore under the "gateway_certificate_alias" alias. For instructions, see [Create and import SSL certificates](../../../../install-and-setup/setup/security/configuring-keystores/keystore-basics/creating-new-keystores).
 
-    !!! Note
+    ??? note
         This is not applicable if you use the default certificates, which are the certificates that are shipped with the product itself.
 
 6. Follow the steps given below to configure High Availability (HA) for the Universal Gateway:
@@ -198,7 +198,7 @@ Follow the instructions given below to configure the Gateway node so that it can
 
     2. Configure a load balancer fronting the two Gateway nodes in your deployment. For instructions, see [Configuring the Proxy Server and the Load Balancer](../../../../install-and-setup/setup/setting-up-proxy-server-and-the-load-balancer/configuring-the-proxy-server-and-the-load-balancer).
 
-        !!! Note
+        ??? note
             To keep custom runtime artifacts deployed in the Gateway, add the following configuration in the `<UNIVERSAL-GW_HOME>/repository/conf/deployment.toml` file of the Gateway nodes.
 
             ```toml


### PR DESCRIPTION
## Summary
- Fixed non-expandable note section in Step 4 of distributed deployment setup documentation
- Changed static '!!! Note' format to expandable '??? note' format with proper indentation
- Enables users to expand/collapse note sections for better user experience

## Changes Made
- Updated docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-simple-scalable-setup.md
- Changed 3 note sections from static to expandable format
- Added proper indentation for collapsible note content

## Test Plan
- [x] Verified syntax follows Material for MkDocs admonition standards
- [x] Confirmed proper indentation for collapsible content
- [ ] Local testing requires Python/MkDocs setup (to be verified by reviewer)

## Related PRs
- v4.5.0 fix: #157

## Fixes
Resolves #143 for v4.6.0

🤖 Generated with [Claude Code](https://claude.ai/code)