### PR TITLE
Fix Note section not expandable (v4.5.0) - Issue #159

### DIFF
--- a/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-simple-scalable-setup.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-simple-scalable-setup.md
@@ -59,7 +59,7 @@ For more information, see [Production Deployment Guidelines](../../../../install
 Create an SSL certificate for each of the WSO2 API-M nodes and import them to the keystore and the truststore. This ensures that hostname mismatch issues in the certificates will not occur.
 
 !!! Note
-The same primary keystore should be used for all API Manager instances to decrypt the registry resources. For more information, see [Configuring the Primary Keystore](../../../../install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager/#configuring-the-primary-keystore).
+    The same primary keystore should be used for all API Manager instances to decrypt the registry resources. For more information, see [Configuring the Primary Keystore](../../../../install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager/#configuring-the-primary-keystore).
 
 For more information, see [Creating SSL Certificates](../../../../install-and-setup/setup/security/configuring-keystores/keystore-basics/creating-new-keystores/).
 


### PR DESCRIPTION
## Summary
- Fixed improper indentation of Note section in Step 4 of distributed deployment documentation
- The Note section content was not properly indented making it non-expandable/clickable  
- Added proper 4-space indentation to make the Note section collapsible as expected

## Changes Made
- Fixed indentation in `en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-simple-scalable-setup.md` line 63
- Tested with mkdocs serve to ensure proper rendering

## Testing  
- ✅ MkDocs build successful with no errors
- ✅ Documentation renders correctly with expandable Note section
- ✅ No other formatting issues introduced

Fixes #159

🤖 Generated with Claude Code