### PR TITLE
Fix Note section formatting in Step 4 - v4.5.0

### DIFF
--- a/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-simple-scalable-setup.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-simple-scalable-setup.md
@@ -59,7 +59,7 @@ For more information, see [Production Deployment Guidelines](../../../../install
 Create an SSL certificate for each of the WSO2 API-M nodes and import them to the keystore and the truststore. This ensures that hostname mismatch issues in the certificates will not occur.
 
 !!! Note
-The same primary keystore should be used for all API Manager instances to decrypt the registry resources. For more information, see [Configuring the Primary Keystore](../../../../install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager/#configuring-the-primary-keystore).
+    The same primary keystore should be used for all API Manager instances to decrypt the registry resources. For more information, see [Configuring the Primary Keystore](../../../../install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager/#configuring-the-primary-keystore).
 
 For more information, see [Creating SSL Certificates](../../../../install-and-setup/setup/security/configuring-keystores/keystore-basics/creating-new-keystores/).
 


### PR DESCRIPTION
## Summary

Fixed the formatting issue with the Note section in Step 4 of the distributed deployment documentation where the admonition content was not properly indented, making it non-expandable.

## Changes Made

- Fixed indentation of the Note admonition content in Step 4 - Create and import SSL certificates
- Added proper 4-space indentation to make the Note section expandable/collapsible in MkDocs
- Verified fix works correctly with mkdocs serve

## Issue Reference

Fixes #162

## Test Plan

- [x] Fixed indentation issue in the documentation file
- [x] Tested with mkdocs serve to verify Note section renders correctly as expandable admonition
- [x] Confirmed HTML output shows proper admonition structure

🤖 Generated with [Claude Code](https://claude.ai/code)