### PR TITLE
[4.6.0] Fix issue #184: Fix broken governance artifact anchor links

### DIFF
--- a/en/docs/governance/governance-concept.md
+++ b/en/docs/governance/governance-concept.md
@@ -7,7 +7,7 @@ The governance capabilities in WSO2 API Manager builds upon the following core c
 Entity that is subject to governance enforcement. In the context of API governance, the governance artifact is an API.
 
 ## Ruleset
-A ruleset is a **collection of rules** that define governance policies to be enforced on [governance artifacts](#Artifact). 
+A ruleset is a **collection of rules** that define governance policies to be enforced on [governance artifacts](#artifact). 
 
 In the context of API governance, these rules cover various aspects of API management, including security, compliance, performance, and operational guidelines. Rulesets can be defined at the organization level and later applied through policies to ensure governance enforcement.
 
@@ -27,7 +27,7 @@ Rules within a ruleset can have different **severity levels**, such as:
 
 ## Policy
 
-A policy is a **collection of rulesets** that can be enforced on [governance artifacts](#Artifact) to ensure governance compliance.
+A policy is a **collection of rulesets** that can be enforced on [governance artifacts](#artifact) to ensure governance compliance.
 
 In the context of API governance, policies can be created at the organization level and applied to APIs to enforce governance requirements. They also provide the capability to apply different governance rulesets to different groups of APIs based on organizational needs.
 
@@ -59,7 +59,7 @@ Policies can be configured to take specific actions based on the severity of rul
 
 ## Label  
 
-A **label** is a tag that can be attached to a specific [governance artifact](#Artifact) to categorize them based on specific criteria. 
+A **label** is a tag that can be attached to a specific [governance artifact](#artifact) to categorize them based on specific criteria. 
 
 In the context of API governance, labels help group APIs according to their type, purpose, or any other classification relevant to the organization.  
 


### PR DESCRIPTION
## Summary

Fixed broken anchor links in governance-concept.md that were causing Page Not Found errors.

- Fixed 3 instances of incorrect anchor links from `#Artifact` to `#artifact`
- Links now correctly reference the Artifact heading section  
- Resolves ranuka-laksika/docs-apim#184 (Version 4.6.0)

## Test plan

- [x] Verified anchor links now have correct lowercase casing
- [x] Confirmed all 3 broken links have been fixed:
  - Line 10: `[governance artifacts](#artifact)`
  - Line 30: `[governance artifacts](#artifact)`
  - Line 62: `[governance artifact](#artifact)`

## Files Changed

- `en/docs/governance/governance-concept.md`: Fixed broken anchor links

🤖 Generated with [Claude Code](https://claude.ai/code)