### PR TITLE
[4.6.0] Fix issue #193: Make Note section expandable in distributed deployment guide

### DIFF
--- a/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-simple-scalable-setup.md
+++ b/en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-simple-scalable-setup.md
@@ -59,7 +59,7 @@ For more information, see [Production Deployment Guidelines](../../../../install
 Create an SSL certificate for each of the WSO2 API-M nodes and import them to the keystore and the truststore. This ensures that hostname mismatch issues in the certificates will not occur.
 
 !!! Note
-The same primary keystore should be used for all API Manager instances to decrypt the registry resources. For more information, see [Configuring the Primary Keystore](../../../../install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager/#configuring-the-primary-keystore).
+    The same primary keystore should be used for all API Manager instances to decrypt the registry resources. For more information, see [Configuring the Primary Keystore](../../../../install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager/#configuring-the-primary-keystore).
 
 For more information, see [Creating SSL Certificates](../../../../install-and-setup/setup/security/configuring-keystores/keystore-basics/creating-new-keystores/).
 


### PR DESCRIPTION
## Summary
- Fixed the Note section in Step 4 of distributed deployment guide that was not expandable
- Added proper 4-space indentation to make the MkDocs admonition block work correctly
- The Note section now properly displays as a collapsible/expandable block

## Changes Made
- Modified `en/docs/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-simple-scalable-setup.md`
- Added proper indentation to Note block content in Step 4 - Create and import SSL certificates section

## Test Plan
- [x] Verified MkDocs admonition syntax formatting
- [x] Confirmed the content is properly indented within the Note block
- [x] The Note section will now be expandable/collapsible as expected

Related to #193 (same fix applied to version 4.6.0)

🤖 Generated with [Claude Code](https://claude.ai/code)