### PR TITLE
Fix: broken link to secure vault documentation[4.3.0]

### DIFF
--- a/en/docs/install-and-setup/install/installing-the-product/installing-api-m-as-a-windows-service.md
+++ b/en/docs/install-and-setup/install/installing-the-product/installing-api-m-as-a-windows-service.md
@@ -20,7 +20,7 @@ The configuration file used for wrapping Java Applications by YAJSW is `wrapper.
 
 !!! info
     
-    If you want to set additional properties from an external registry at runtime, store sensitive information like usernames and passwords for connecting to the registry in a properties file and secure it with [secure vault]({{base_path}}/administer/product-security/General/logins-and-passwords/admin-carbon-secure-vault-implementation).
+    If you want to set additional properties from an external registry at runtime, store sensitive information like usernames and passwords for connecting to the registry in a properties file and secure it with [secure vault]({{base_path}}/install-and-setup/setup/security/logins-and-passwords/carbon-secure-vault-implementation).
 
 !!! note
     


### PR DESCRIPTION
## Related Issue
Fixes #342

## Type of Change
- [x] Broken Links

## Summary
Fixed broken link in the Windows service installation documentation that was pointing to an incorrect secure vault documentation path. The link was updated from:
- `{{base_path}}/administer/product-security/General/logins-and-passwords/admin-carbon-secure-vault-implementation`

To the correct path:
- `{{base_path}}/install-and-setup/setup/security/logins-and-passwords/carbon-secure-vault-implementation`

## Verification
- Verified that the target file exists at the corrected path
- Confirmed the broken link was present in the source file before the fix

🤖 Generated with [Claude Code](https://claude.ai/code)