### PR TITLE
Fix: Update broken secure vault link path [4.3.0]

### DIFF
--- a/en/docs/install-and-setup/install/installing-the-product/installing-api-m-as-a-windows-service.md
+++ b/en/docs/install-and-setup/install/installing-the-product/installing-api-m-as-a-windows-service.md
@@ -20,7 +20,7 @@ The configuration file used for wrapping Java Applications by YAJSW is `wrapper.
 
 !!! info
     
-    If you want to set additional properties from an external registry at runtime, store sensitive information like usernames and passwords for connecting to the registry in a properties file and secure it with [secure vault]({{base_path}}/administer/product-security/General/logins-and-passwords/admin-carbon-secure-vault-implementation).
+    If you want to set additional properties from an external registry at runtime, store sensitive information like usernames and passwords for connecting to the registry in a properties file and secure it with [secure vault]({{base_path}}/install-and-setup/setup/security/logins-and-passwords/carbon-secure-vault-implementation).
 
 !!! note
     


### PR DESCRIPTION
Fixes broken secure vault link in installing API-M as Windows service documentation.

## Changes
- Updated broken link from `/administer/product-security/General/logins-and-passwords/admin-carbon-secure-vault-implementation` to `/install-and-setup/setup/security/logins-and-passwords/carbon-secure-vault-implementation`

## Testing
- Verified target file exists at the updated path
- Link now points to correct documentation location

Addresses issue #377 for version 4.3.0