### PR TITLE
Fix: Update broken secure vault documentation link [4.2.0]

### DIFF
--- a/en/docs/install-and-setup/install/installing-the-product/installing-api-m-analytics-as-a-windows-service.md
+++ b/en/docs/install-and-setup/install/installing-the-product/installing-api-m-analytics-as-a-windows-service.md
@@ -43,7 +43,7 @@ The configuration file used for wrapping Java Applications by YAJSW is `wrapper.
 
 !!! info
     
-    If you want to set additional properties from an external registry at runtime, store sensitive information like usernames and passwords for connecting to the registry in a properties file and secure it with [secure vault]({{base_path}}/administer/product-security/General/logins-and-passwords/admin-carbon-secure-vault-implementation).
+    If you want to set additional properties from an external registry at runtime, store sensitive information like usernames and passwords for connecting to the registry in a properties file and secure it with [secure vault]({{base_path}}/install-and-setup/setup/security/logins-and-passwords/working-with-encrypted-passwords/).
 
 !!! note
     

--- a/en/docs/install-and-setup/install/installing-the-product/installing-si-as-windows-service.md
+++ b/en/docs/install-and-setup/install/installing-the-product/installing-si-as-windows-service.md
@@ -20,7 +20,7 @@ The configuration file used for wrapping Java Applications by YAJSW is `wrapper.
 
 !!! info
     
-    If you want to set additional properties from an external registry at runtime, store sensitive information like usernames and passwords for connecting to the registry in a properties file and secure it with [secure vault]({{base_path}}/administer/product-security/General/logins-and-passwords/admin-carbon-secure-vault-implementation).
+    If you want to set additional properties from an external registry at runtime, store sensitive information like usernames and passwords for connecting to the registry in a properties file and secure it with [secure vault]({{base_path}}/install-and-setup/setup/security/logins-and-passwords/working-with-encrypted-passwords/).
 
 
 !!! tip


### PR DESCRIPTION
## Summary
- Fixed broken secure vault documentation link in Windows service installation files for version 4.2.0
- Updated links from `/administer/product-security/General/logins-and-passwords/admin-carbon-secure-vault-implementation` to `/install-and-setup/setup/security/logins-and-passwords/working-with-encrypted-passwords/`
- Files updated: installing-api-m-analytics-as-a-windows-service.md, installing-si-as-windows-service.md

## Test plan
- [x] Verified the broken link existed in version 4.2.0 in specific files
- [x] Verified the target secure vault file exists at the correct path for this version
- [x] Updated all links to point to the correct location for version 4.2.0
- [x] Tested that the documentation builds without errors

🤖 Generated with [Claude Code](https://claude.ai/code)