### PR TITLE
Fix spelling and grammar errors in API Manager docs (v4.1.0)

### DIFF
--- a/en/.spelling
+++ b/en/.spelling
@@ -1498,7 +1498,7 @@ allowlisted
 id_token
 API-M_HOME
 wso2-BotDetectedData
-valdators
+validators
 Am300JSON
 preconfigured
 validator
@@ -6476,7 +6476,7 @@ Informix
 4.10.JC2
 changing-to-ibm-informix
 Walkthrough
-valdators
+validators
 Am300JSON
 preconfigured
 validator

--- a/en/docs/design/api-security/threat-protection/gateway-threat-protectors/gateway-threat-protectors-for-api-manager.md
+++ b/en/docs/design/api-security/threat-protection/gateway-threat-protectors/gateway-threat-protectors-for-api-manager.md
@@ -8,7 +8,7 @@ WSO2 API Manager has three types of threat protectors for the Gateway.
 
 ### Combining threat protectors
 
-You can use a combination of the threat protectors given above to validate the messages and protect your gateway from attacks. An example custom mediation policy which which validates the API request against XML and regex valdators is given below.
+You can use a combination of the threat protectors given above to validate the messages and protect your gateway from attacks. An example custom mediation policy which validates the API request against XML and regex validators is given below.
 
 ``` java
 <sequence xmlns="http://ws.apache.org/ns/synapse" name="combinevalidator">


### PR DESCRIPTION
## Summary

- Fix spelling error: "valdators" -> "validators" in .spelling file (2 occurrences)
- Fix grammar error: "which which validates" -> "which validates" in gateway-threat-protectors-for-api-manager.md

## Files Changed

- `.spelling`: Fixed spelling of "valdators" to "validators"
- `docs/design/api-security/threat-protection/gateway-threat-protectors/gateway-threat-protectors-for-api-manager.md`: Fixed duplicate "which" in sentence

## Test Plan

- [x] Verified spelling corrections in .spelling file
- [x] Verified grammar correction in markdown file
- [x] No functional changes, only textual corrections

🤖 Generated with [Claude Code](https://claude.ai/code)