### PR TITLE
Fix broken link to test-a-rest-api in design-api-overview.md (version 4.3.0)

### DIFF
--- a/en/docs/design/design-api-overview.md
+++ b/en/docs/design/design-api-overview.md
@@ -64,7 +64,7 @@ API documentation helps API subscribers to understand the functionality of the A
 
 ## Test APIs
 
-You can test APIs directly in the API Publisher itself. Refer to [documentation on testing REST APIs]({{base_path}}/design/create-api/test-a-rest-api) for more information.
+You can test APIs directly in the API Publisher itself. Refer to [documentation on testing REST APIs]({{base_path}}/design/create-api/create-rest-api/test-a-rest-api) for more information.
 
 ## API Revisions
 


### PR DESCRIPTION
## Summary
- Fixed broken link in design-api-overview.md for version 4.3.0
- Updated link from `{{base_path}}/design/create-api/test-a-rest-api` to `{{base_path}}/design/create-api/create-rest-api/test-a-rest-api`

## Test plan
- [ ] Verify the link now points to the correct documentation page
- [ ] Check that the page builds correctly without broken links

Generated with [Claude Code](https://claude.ai/code)