### PR TITLE
Fix: HashiCorp Vault documentation typos and Log4j2 property key error (v4.1.0)

### DIFF
--- a/en/docs/install-and-setup/setup/security/logins-and-passwords/harshicrop-vault-extension.md
+++ b/en/docs/install-and-setup/setup/security/logins-and-passwords/harshicrop-vault-extension.md
@@ -1,7 +1,7 @@
 
 # Integrate with HashiCorp Vault
 
-Using [HashiCorp Vault extension](https://github.com/wso2-extensions/carbon-securevault-hashicorp/tree/master), you can set up HashiCorp Vault to store passwords that are mapped to aliases instead of the actual passwords. When setting up Hashicrop Vault with APIM you can use either of the following authentication methords, based on your requirment.
+Using [HashiCorp Vault extension](https://github.com/wso2-extensions/carbon-securevault-hashicorp/tree/master), you can set up HashiCorp Vault to store passwords that are mapped to aliases instead of the actual passwords. When setting up HashiCorp Vault with APIM you can use either of the following authentication methods, based on your requirement.
    
 1. Using Root Token authentication
 2. Using App-Role authentication
@@ -66,7 +66,7 @@ This method uses a static root token to authenticate with HashiCorp Vault, provi
     logger.org-wso2-carbon-securevault-hashicorp.name=org.wso2.carbon.securevault.hashicorp
     logger.org-wso2-carbon-securevault-hashicorp.level=INFO
     logger.org-wso2-carbon-securevault-hashicorp.additivity=false
-    logger.org-wso2-carbon-securevault-hashicorp.appenderRefCARBON_CONSOLE.ref = CARBON_CONSOLE
+    logger.org-wso2-carbon-securevault-hashicorp.appenderRef.CARBON_CONSOLE.ref = CARBON_CONSOLE
     ```
 
 6. Then append `org-wso2-carbon-securevault-hashicorp` to the `loggers` list in the same file as follows.


### PR DESCRIPTION
## Summary
This PR fixes typos and formatting errors in the HashiCorp Vault extension documentation for version 4.1.0:

- Fixed "Hashicrop" → "HashiCorp" in line 4
- Fixed "methords" → "methods" in line 4  
- Fixed "requirment" → "requirement" in line 4
- Fixed Log4j2 property key: "appenderRefCARBON_CONSOLE" → "appenderRef.CARBON_CONSOLE"

## Test plan
- [x] Verified typos are corrected
- [x] Confirmed Log4j2 property syntax is now correct
- [x] Documentation builds without errors

Related to issue #477