### PR TITLE
Fix broken link in design-api-overview.md for version 4.2.0

### DIFF
--- a/en/docs/design/design-api-overview.md
+++ b/en/docs/design/design-api-overview.md
@@ -64,7 +64,7 @@ API documentation helps API subscribers to understand the functionality of the A
 
 ## Test APIs
 
-You can test APIs directly in the API Publisher itself. Refer to [documentation on testing REST APIs]({{base_path}}/design/create-api/test-a-rest-api) for more information.
+You can test APIs directly in the API Publisher itself. Refer to [documentation on testing REST APIs]({{base_path}}/design/create-api/create-rest-api/test-a-rest-api) for more information.
 
 ## API Revisions
 


### PR DESCRIPTION
## Summary
- Fixed broken link in design-api-overview.md that was missing the `create-rest-api/` path segment
- Link now correctly points to `{{base_path}}/design/create-api/create-rest-api/test-a-rest-api`

## Test plan
- [x] Verified that the target file exists at the correct path
- [x] Confirmed the link format matches existing patterns in the documentation

🤖 Generated with [Claude Code](https://claude.ai/code)