### PR TITLE
Add note about enabling Token Exchange grant type in Resident Key Manager (4.3.0)

### DIFF
--- a/en/docs/administer/key-managers/configure-custom-connector.md
+++ b/en/docs/administer/key-managers/configure-custom-connector.md
@@ -129,6 +129,8 @@ When registering a third-party Identity Provider as a Key Manager in the Admin P
     * Get an API Manager token by invoking the token endpoint of API Manager with the required parameters (i.e., the token obtained from the external Identity Provider)
     * Invoke the API with the exchanged token
 
+!!! note
+    When configuring an external Key Manager with only the **Token Exchange** API invocation method, ensure that the **Token Exchange** grant type is enabled in the Resident Key Manager for the token exchange process to work correctly.
 
 1. Sign in to the Admin Portal using the following URL: `https://<hostname>:9443/admin`
 


### PR DESCRIPTION
## Summary
- Adds a note about the need to enable Token Exchange grant type in the Resident Key Manager when configuring external Key Manager with Token Exchange API invocation method
- This ensures users understand the prerequisite configuration for token exchange to work properly

## Test plan
- [x] Verified the documentation renders correctly
- [x] Confirmed the note appears in the appropriate location after the Token Exchange explanation
- [x] No breaking changes to existing documentation structure

🤖 Generated with [Claude Code](https://claude.ai/code)