### PR TITLE
Fix: Add note about Token Exchange grant type requirement for external Key Manager [4.4.0]

### DIFF
--- a/en/docs/administer/key-managers/configure-custom-connector.md
+++ b/en/docs/administer/key-managers/configure-custom-connector.md
@@ -129,6 +129,8 @@ When registering a third-party Identity Provider as a Key Manager in the Admin P
     * Get an API Manager token by invoking the token endpoint of API Manager with the required parameters (i.e., the token obtained from the external Identity Provider)
     * Invoke the API with the exchanged token
 
+    !!! important "Note"
+        When configuring an external Key Manager with only the token exchange invocation method, ensure that the **Token Exchange grant type is enabled** in the Resident Key Manager.
 
 1. Sign in to the Admin Portal using the following URL: `https://<hostname>:9443/admin`
 


### PR DESCRIPTION
## Summary

- Add missing important note in the Token Exchange API invocation method section
- The note informs users to ensure Token Exchange grant type is enabled in the Resident Key Manager when configuring an external Key Manager with only the token exchange invocation method

## Test plan

- [x] Verified the note is correctly placed after the Token Exchange expandable note section
- [x] Confirmed the markdown formatting is correct

🤖 Generated with [Claude Code](https://claude.ai/code)