### PR TITLE
Fix: Correct typos and Log4j2 property in HashiCorp Vault integration documentation (4.1.0)

### DIFF
--- a/en/docs/install-and-setup/setup/security/logins-and-passwords/harshicrop-vault-extension.md
+++ b/en/docs/install-and-setup/setup/security/logins-and-passwords/harshicrop-vault-extension.md
@@ -1,7 +1,7 @@
 
 # Integrate with HashiCorp Vault
 
-Using [HashiCorp Vault extension](https://github.com/wso2-extensions/carbon-securevault-hashicorp/tree/master), you can set up HashiCorp Vault to store passwords that are mapped to aliases instead of the actual passwords. When setting up Hashicrop Vault with APIM you can use either of the following authentication methords, based on your requirment.
+Using [HashiCorp Vault extension](https://github.com/wso2-extensions/carbon-securevault-hashicorp/tree/master), you can set up HashiCorp Vault to store passwords that are mapped to aliases instead of the actual passwords. When setting up HashiCorp Vault with APIM you can use either of the following authentication methods, based on your requirement.
    
 1. Using Root Token authentication
 2. Using App-Role authentication
@@ -66,7 +66,7 @@ This method uses a static root token to authenticate with HashiCorp Vault, provi
     logger.org-wso2-carbon-securevault-hashicorp.name=org.wso2.carbon.securevault.hashicorp
     logger.org-wso2-carbon-securevault-hashicorp.level=INFO
     logger.org-wso2-carbon-securevault-hashicorp.additivity=false
-    logger.org-wso2-carbon-securevault-hashicorp.appenderRefCARBON_CONSOLE.ref = CARBON_CONSOLE
+    logger.org-wso2-carbon-securevault-hashicorp.appenderRef.CARBON_CONSOLE.ref = CARBON_CONSOLE
     ```
 
 6. Then append `org-wso2-carbon-securevault-hashicorp` to the `loggers` list in the same file as follows.

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -1425,7 +1425,7 @@ nav:
                             - Work with Encrypted Passwords: install-and-setup/setup/security/logins-and-passwords/working-with-encrypted-passwords.md
                             - Set Up ReCaptcha: install-and-setup/setup/security/logins-and-passwords/setting-up-recaptcha.md
                             - Configure reCaptcha for Single Sign On : install-and-setup/setup/security/logins-and-passwords/configuring-recaptcha-for-single-sign-on.md
-                            - Intergrate with HashiCorp Vault : install-and-setup/setup/security/logins-and-passwords/harshicrop-vault-extension.md
+                            - Integrate with HashiCorp Vault : install-and-setup/setup/security/logins-and-passwords/harshicrop-vault-extension.md
                     - Configure Keystores:
                         - Configure Keystores in API Manager: install-and-setup/setup/security/configuring-keystores/configuring-keystores-in-wso2-api-manager.md
                         - Keystore Basics:


### PR DESCRIPTION
## Summary
- Fixed typos in HashiCorp Vault documentation: "Hashicrop" → "HashiCorp", "methords" → "methods", "requirment" → "requirement"
- Corrected Log4j2 property syntax: added missing dot in `appenderRef.CARBON_CONSOLE.ref`
- Fixed "Intergrate" → "Integrate" in mkdocs.yml

## Test plan
- [x] Verify all typos are corrected in the documentation file
- [x] Confirm Log4j2 property syntax is correct
- [x] Check mkdocs.yml navigation entry is properly spelled

🤖 Generated with [Claude Code](https://claude.ai/code)