### PR TITLE
Fix: Update vcs-config-path example to include full file path [4.4.0]

### DIFF
--- a/en/docs/install-and-setup/setup/api-controller/advanced-topics/configuring-git-integration.md
+++ b/en/docs/install-and-setup/setup/api-controller/advanced-topics/configuring-git-integration.md
@@ -88,8 +88,8 @@ apictl set --vcs-config-path <full-path-to-store-vcs_config.yaml>
 
 !!! example
     ```bash
-    apictl set --vcs-config-path /home/wso2/api-manager/gitconfigs
-    VCS config file path is set to : /home/wso2/api-manager/gitconfigs
+    apictl set --vcs-config-path /home/wso2/api-manager/gitconfigs/vcs_config.yaml
+    VCS config file path is set to : /home/wso2/api-manager/gitconfigs/vcs_config.yaml
     ```
 
 By setting the above, `apictl vcs deploy` command will create the `vcs_config.yaml` if it is not available in the specified path and reuse it for the succeeding commands.


### PR DESCRIPTION
## Summary

The `vcs-config-path` parameter expects the full path to the `vcs_config.yaml` file, not just the directory path. This change updates the example to show the correct usage with the complete file path.

## Changes Made

- Updated example from `/home/wso2/api-manager/gitconfigs` to `/home/wso2/api-manager/gitconfigs/vcs_config.yaml`
- Ensured both the command example and output example reflect the correct file path

## Impact

This fix ensures that users have the correct example when configuring the VCS config path, preventing confusion and potential errors when setting up Git integration.

## Testing

- Verified the change matches the expected format for the vcs-config-path parameter
- Confirmed the documentation now aligns with the actual behavior of the apictl tool

Fixes #675

🤖 Generated with [Claude Code](https://claude.ai/code)