### PR TITLE
Fix: Broken link to testing REST APIs documentation [4.2.0]

### DIFF
--- a/en/docs/design/design-api-overview.md
+++ b/en/docs/design/design-api-overview.md
@@ -64,7 +64,7 @@ API documentation helps API subscribers to understand the functionality of the A
 
 ## Test APIs
 
-You can test APIs directly in the API Publisher itself. Refer to [documentation on testing REST APIs]({{base_path}}/design/create-api/test-a-rest-api) for more information.
+You can test APIs directly in the API Publisher itself. Refer to [documentation on testing REST APIs]({{base_path}}/design/create-api/create-rest-api/test-a-rest-api) for more information.
 
 ## API Revisions
 


### PR DESCRIPTION
## Summary

This PR fixes a broken link in the API design overview documentation that was pointing to an incorrect path.

**Issue:** The link `{{base_path}}/design/create-api/test-a-rest-api` in `/docs/design/design-api-overview.md` was missing the `create-rest-api` directory segment, causing it to point to a non-existent location.

**Fix:** Updated the link to `{{base_path}}/design/create-api/create-rest-api/test-a-rest-api` to correctly reference the target file at `/docs/design/create-api/create-rest-api/test-a-rest-api.md`.

## Files Changed

- `/docs/design/design-api-overview.md` - Fixed broken link in "Test APIs" section (line 67)

## Test Plan

- [x] Verified the target file exists at the corrected path
- [x] Confirmed the link structure matches other working links in the same file
- [x] Validated that the fix follows the established URL pattern used throughout the documentation

🤖 Generated with [Claude Code](https://claude.ai/code)