### PR TITLE
Fix VCS config path documentation for apictl command - Issue #713 (v4.5.0)

### DIFF
--- a/en/docs/install-and-setup/setup/api-controller/advanced-topics/configuring-git-integration.md
+++ b/en/docs/install-and-setup/setup/api-controller/advanced-topics/configuring-git-integration.md
@@ -83,13 +83,13 @@ The structure of the file is as per below:
 Unlike the other configuration files inside `.wso2apictl`, `vcs_config.yaml` maintains a state for each repository. So it is mandatory to persist it during each `apictl vcs` command execution during each build cycle. In some container-based build systems, it might be difficult to keep this file persisted and make it available for each build cycle as it is required to enable volume mounts etc. It is also not advisable to persist/share the full `.wso2apictl` folder as it might include credentials. In such cases, an alternative approach would be to externalize the `vcs_config.yaml` into a different location where volume mounts or some persistence mechanism can be enabled for  `vcs_config.yaml` only.
 
 ```bash
-apictl set --vcs-config-path <full-path-to-store-vcs_config.yaml>
+apictl set --vcs-config-path <full-path-to-vcs_config.yaml>
 ```
 
 !!! example
     ```bash
-    apictl set --vcs-config-path /home/wso2/api-manager/gitconfigs
-    VCS config file path is set to : /home/wso2/api-manager/gitconfigs
+    apictl set --vcs-config-path /home/wso2/api-manager/gitconfigs/vcs_config.yaml
+    VCS config file path is set to : /home/wso2/api-manager/gitconfigs/vcs_config.yaml
     ```
 
 By setting the above, `apictl vcs deploy` command will create the `vcs_config.yaml` if it is not available in the specified path and reuse it for the succeeding commands.


### PR DESCRIPTION
## Summary

Fix VCS config path documentation for apictl command in configuring-git-integration.md

### Changes Made:
- **Line 86**: Changed `<full-path-to-store-vcs_config.yaml>` to `<full-path-to-vcs_config.yaml>` to be more accurate and concise
- **Lines 91-92**: Updated example to show full path including filename:
  - Changed from: `/home/wso2/api-manager/gitconfigs` 
  - Changed to: `/home/wso2/api-manager/gitconfigs/vcs_config.yaml`

### Issue Reference:
Fixes issue #713 - Documentation shows incorrect VCS config path format

### Test Plan:
- [x] Verified the documentation changes are consistent with the command behavior
- [x] Checked that all three instances of the path are updated correctly
- [x] Ensured formatting and markdown syntax remain correct

🤖 Generated with [Claude Code](https://claude.ai/code)