### PR TITLE
Fix: Broken link in Test APIs section (4.5.0)

### DIFF
--- a/en/docs/manage-apis/design/design-api-overview.md
+++ b/en/docs/manage-apis/design/design-api-overview.md
@@ -64,7 +64,7 @@ API documentation helps API subscribers to understand the functionality of the A
 
 ## Test APIs
 
-You can test APIs directly in the API Publisher itself. Refer to [documentation on testing REST APIs]({{base_path}}/manage-apis/design/create-api/test-a-rest-api) for more information.
+You can test APIs directly in the API Publisher itself. Refer to [documentation on testing REST APIs]({{base_path}}/manage-apis/design/create-api/create-rest-api/test-a-rest-api) for more information.
 
 ## API Revisions
 


### PR DESCRIPTION
## Summary
- Fixed broken link in Test APIs section of design-api-overview.md
- The link was pointing to `create-api/test-a-rest-api` but the actual file is located at `create-api/create-rest-api/test-a-rest-api.md`
- Updated the link to point to the correct path

## Test plan
- [x] Verified the target file exists at the correct path
- [x] Confirmed the link pattern matches other documentation links
- [x] Tested that the link resolves correctly

🤖 Generated with [Claude Code](https://claude.ai/code)