### PR TITLE
Fix broken link to test-a-rest-api documentation in version 4.0.0

### DIFF
--- a/en/docs/design/design-api-overview.md
+++ b/en/docs/design/design-api-overview.md
@@ -64,7 +64,7 @@ API documentation helps API subscribers to understand the functionality of the A
 
 ## Test APIs
 
-You can test APIs directly in the API Publisher itself. Refer to [documentation on testing REST APIs]({{base_path}}/design/create-api/test-a-rest-api) for more information.
+You can test APIs directly in the API Publisher itself. Refer to [documentation on testing REST APIs]({{base_path}}/design/create-api/create-rest-api/test-a-rest-api) for more information.
 
 ## API Revisions
 


### PR DESCRIPTION
## Summary
- Fix broken link in design-api-overview.md file
- Corrected path from `design/create-api/test-a-rest-api` to `design/create-api/create-rest-api/test-a-rest-api`
- This aligns the link with the actual file structure in version 4.0.0

## Test plan
- [x] Verified the correct file path exists in the repository
- [x] Updated the link to match the actual file structure
- [x] Confirmed the fix resolves the broken link issue

🤖 Generated with [Claude Code](https://claude.ai/code)