### PR TITLE
Fix: Update vcs-config-path example to include filename [4.1.0]

### DIFF
--- a/en/docs/install-and-setup/setup/api-controller/advanced-topics/configuring-git-integration.md
+++ b/en/docs/install-and-setup/setup/api-controller/advanced-topics/configuring-git-integration.md
@@ -86,8 +86,8 @@ apictl set --vcs-config-path <full-path-to-store-vcs_config.yaml>
 
 !!! example
     ```bash
-    $ apictl set --vcs-config-path /home/wso2/api-manager/gitconfigs
-    VCS config file path is set to : /home/wso2/api-manager/gitconfigs
+    $ apictl set --vcs-config-path /home/wso2/api-manager/gitconfigs/vcs_config.yaml
+    VCS config file path is set to : /home/wso2/api-manager/gitconfigs/vcs_config.yaml
     ```
 
 By setting the above, `apictl vcs deploy` command will create the `vcs_config.yaml` if it is not available in the specified path and reuse it for the succeeding commands.


### PR DESCRIPTION
## Summary
- Fixed the vcs-config-path example in configuring-git-integration.md to include the full filename
- Updated example to show `/home/wso2/api-manager/gitconfigs/vcs_config.yaml` instead of just the directory path
- This provides clearer guidance to users on the expected file path format

## Test plan
- [x] Verify the documentation example is now accurate
- [x] Confirm the file path format matches expected usage patterns

🤖 Generated with [Claude Code](https://claude.ai/code)