### PR TITLE
Fix: broken link in documentation on testing REST APIs 4.0.0

### DIFF
--- a/en/docs/design/design-api-overview.md
+++ b/en/docs/design/design-api-overview.md
@@ -64,7 +64,7 @@ API documentation helps API subscribers to understand the functionality of the A
 
 ## Test APIs
 
-You can test APIs directly in the API Publisher itself. Refer to [documentation on testing REST APIs]({{base_path}}/design/create-api/test-a-rest-api) for more information.
+You can test APIs directly in the API Publisher itself. Refer to [documentation on testing REST APIs]({{base_path}}/design/create-api/create-rest-api/test-a-rest-api) for more information.
 
 ## API Revisions
 


### PR DESCRIPTION
Fixes the broken link in the design-api-overview.md file for testing REST APIs.

**Issue**: The documentation referenced a broken link for testing REST APIs
**Root cause**: The link path was missing the 'create-rest-api' directory component  
**Solution**: Updated the link from `{{base_path}}/design/create-api/test-a-rest-api` to `{{base_path}}/design/create-api/create-rest-api/test-a-rest-api`

**Files changed**: 
- `en/docs/design/design-api-overview.md`: Fixed the broken link in the Test APIs section

Fixes #805