### PR TITLE
Fix: Correct tip box formatting in adding-new-tenants documentation [4.2.0]

### DIFF
--- a/en/docs/administer/multitenancy/adding-new-tenants.md
+++ b/en/docs/administer/multitenancy/adding-new-tenants.md
@@ -85,10 +85,10 @@ You can invoke these operations using a SOAP client like SOAP UI as follows:
 
     ![]({{base_path}}/assets/attachments/126562777/126562782.png)
     !!! warning
-            Before invoking an operation:
+        Before invoking an operation:
 
-            -   Be sure to set the admin user's credentials for authorization in the SOAP UI.
-            -   Note that it is **not recommended** to delete tenants.
+        -   Be sure to set the admin user's credentials for authorization in the SOAP UI.
+        -   Note that it is **not recommended** to delete tenants.
 
 
 4.  Click on the operation to open the request view. For example, to activate a tenant use the `activateTenant` operation.


### PR DESCRIPTION
## Summary
- Fixed incorrect indentation for `!!! warning` block content in the adding-new-tenants.md file
- Changed warning text and list items from 12 spaces to 8 spaces for proper admonition formatting
- Ensures consistent alignment within the warning admonition block for version 4.2.0

## Test plan
- [x] Verified the file exists in version 4.2.0
- [x] Identified incorrect indentation in warning block content
- [x] Applied fix to reduce indentation from 12 spaces to 8 spaces
- [x] Confirmed proper admonition formatting after the change

🤖 Generated with [Claude Code](https://claude.ai/code)