### PR TITLE
Fix: Correct JSON formatting for SelfSignUp configuration documentation [4.2.0]

### DIFF
--- a/en/docs/reference/customize-product/customizations/customizing-the-developer-portal/enabling-or-disabling-self-signup.md
+++ b/en/docs/reference/customize-product/customizations/customizing-the-developer-portal/enabling-or-disabling-self-signup.md
@@ -23,10 +23,10 @@ In a multi-tenanted API Manager setup, self-signup to the Developer Portal works
     ![Advance Configuration Admin Portal Self Signup]({{base_path}}/assets/img/learn/advance-configuration-admin-portal-self-signup.png)
 
 6. Remove the following configuration and save the content.
-    ``` json
-       "SelfSignUp": {
-            "SignUpRoles":["Internal/subscriber"]
-       }
+    ```json
+    "SelfSignUp": {
+       "SignUpRoles":["Internal/subscriber"]
+    }
     ```
 7. When trying to register as a new user on the particular tenant domain, you will see the following message notifying that self registration is disabled.
 
@@ -47,10 +47,10 @@ In a multi-tenanted API Manager setup, self-signup to the Developer Portal works
 
 6. Add the following configuration and save the content.
 
-    ``` json
-       "SelfSignUp": {
-            "SignUpRoles":["Internal/subscriber"]
-       }
+    ```json
+    "SelfSignUp": {
+       "SignUpRoles":["Internal/subscriber"]
+    }
     ```
 !!! Note
     To enable email verification, update the `repository/deployment/server/webapps/accountrecoveryendpoint/WEB-INF/web.xml` file by setting the `EnableEmailNotification` parameter to `true`:


### PR DESCRIPTION
## Summary

This PR fixes JSON formatting issues in the SelfSignUp configuration documentation for the 4.2.0 branch. The changes address issue #939 by:

- Correcting JSON code block syntax from ``` json to ```json (without space)
- Fixing indentation to follow proper JSON formatting standards
- Applying consistent formatting in both "disabling" and "enabling" sections

## Changes Made

1. **Fixed JSON code block syntax**: Changed ``` json to ```json for proper syntax highlighting
2. **Corrected indentation**: Adjusted JSON object indentation to be consistent and properly formatted
3. **Applied to both sections**: Fixed formatting in both the "Disabling Self Signup" and "Enabling Self Signup" sections

## Files Modified

- en/docs/reference/customize-product/customizations/customizing-the-developer-portal/enabling-or-disabling-self-signup.md

## Before and After

**Before:**
``` json
   "SelfSignUp": {
        "SignUpRoles":["Internal/subscriber"]
   }

**After:**
```json
"SelfSignUp": {
   "SignUpRoles":["Internal/subscriber"]
}

## Testing

- Verified that the JSON formatting is now consistent and properly structured
- Confirmed that both occurrences in the document have been corrected
- Ensured no other content was affected

Fixes #939

Generated with Claude Code